### PR TITLE
Populate Update Check URLs on install

### DIFF
--- a/upload/library/AddOnInstaller/ControllerAdmin/AddOn.php
+++ b/upload/library/AddOnInstaller/ControllerAdmin/AddOn.php
@@ -523,7 +523,7 @@ class AddOnInstaller_ControllerAdmin_AddOn extends XFCP_AddOnInstaller_Controlle
 
     public function actionUpdateCheckAll()
     {
-        XenForo_Model::create('XenForo_Model_AddOn')->checkForUpdates();
+        $this->_getAddOnModel()->checkForUpdates();
 
         return $this->responseRedirect(
             XenForo_ControllerResponse_Redirect::SUCCESS,

--- a/upload/library/AddOnInstaller/DataWriter/Updater.php
+++ b/upload/library/AddOnInstaller/DataWriter/Updater.php
@@ -58,6 +58,7 @@ class AddOnInstaller_DataWriter_Updater extends XenForo_DataWriter
      */
     protected function _verifyUpdateUrl(&$resourceUrl)
     {
+        $resourceUrl = trim($resourceUrl);
         if ($this->_getAddOnModel()->isResourceUrl($resourceUrl))
         {
             $resourceUrl = rtrim($resourceUrl, '/');

--- a/upload/library/AddOnInstaller/Install.php
+++ b/upload/library/AddOnInstaller/Install.php
@@ -71,6 +71,15 @@ class AddOnInstaller_Install
                 $cronEntry[0] = json_encode($entry);
             }
         }
+
+        // if this addon is disabled, and then upgraded via XenForo addon upgrade proccess, 
+        // the method that is expected to exist will not.
+        $addOnModel = XenForo_Model::create("XenForo_Model_AddOn");
+        if (method_exists($addOnModel, 'bulkUpdateAddOnCheck'))
+        {
+            // scan existing addons and load their url if it looks like something we support updating from.
+            $addOnModel->bulkUpdateAddOnCheck();
+        }
     }
 
     public static function uninstaller()


### PR DESCRIPTION
Installer now determines if it can populate addon update check configuration from existing add-on data.

@NixFifty any thoughts on this sort of functionality? 

Using the add-on url's often points to the XF.com resource (or some resource manager resource), and it saves painfully clicking through many many add-ons if it can be automatically setup.
