### PR TITLE
Add a rebuild add-on caches link

### DIFF
--- a/addon-AddOnInstaller.xml
+++ b/addon-AddOnInstaller.xml
@@ -4,6 +4,7 @@
     <navigation navigation_id="AddonInstallLog" parent_navigation_id="addOns" display_order="300" link="add-ons/install-log" admin_permission_id="addOn" debug_only="0" hide_no_children="0"/>
     <navigation navigation_id="InstallUpgrade" parent_navigation_id="addOns" display_order="100" link="add-ons/install-upgrade" admin_permission_id="addOn" debug_only="0" hide_no_children="0"/>
     <navigation navigation_id="UpdateCheck" parent_navigation_id="addOns" display_order="200" link="add-ons/update-check" admin_permission_id="addOn" debug_only="0" hide_no_children="0"/>
+    <navigation navigation_id="addon_rebuild_caches" parent_navigation_id="addOns" display_order="150" link="add-ons/rebuild-caches" admin_permission_id="addOn" debug_only="0" hide_no_children="0"/>
   </admin_navigation>
   <admin_permissions/>
   <admin_style_properties/>
@@ -354,6 +355,19 @@
 <p class="sectionFooter">{xen:phrase showing_x_of_y_items, 'count=<span class="FilterListCount">{xen:count $addOns}</span>', 'total={xen:count $addOns}'}</p>
 
 </xen:form>]]></template>
+    <template title="addon_rebuild_caches"><![CDATA[<xen:title>{xen:phrase confirm_rebuild_of_add_on_caches}</xen:title>
+<xen:h1>{xen:phrase confirm_rebuild_of_add_on_caches}</xen:h1>
+
+<xen:require css="public:delete_confirmation.css" />
+
+<xen:form action="{xen:adminlink 'add-ons/rebuild-caches'}" class="deleteConfirmForm formOverlay">
+
+	<p>{xen:phrase please_confirm_that_you_want_to_rebuild_add_on_caches}</p>
+
+	<xen:submitunit save="{xen:phrase add_on_rebuild_caches}" />
+	
+	<input type="hidden" name="_xfConfirm" value="1" />
+</xen:form>]]></template>
     <template title="addon_update_skip"><![CDATA[<xen:title>{xen:phrase confirm_skip_current_update}: {$addOn.title} ({xen:phrase version} {$addOn.latest_update})</xen:title>
 <xen:h1>{xen:phrase confirm_skip_update}</xen:h1>
 
@@ -455,7 +469,9 @@ $1]]></replace>
     <phrase title="addon_start_install" version_id="1030000" version_string="1.3.0"><![CDATA[Confirm & start installing]]></phrase>
     <phrase title="addon_update_has_been_skipped" version_id="10" version_string="1.0.0 RC4"><![CDATA[Add-on update has been ignored]]></phrase>
     <phrase title="add_ons_to_install_or_upgrade" version_id="1030000" version_string="1.3.0"><![CDATA[Add-ons to install or Upgrade]]></phrase>
+    <phrase title="add_on_rebuild_caches" version_id="1030000" version_string="1.3.0"><![CDATA[Rebuild caches]]></phrase>
     <phrase title="admin_navigation_AddonInstallLog" version_id="1030000" version_string="1.3.0"><![CDATA[Add-on Install Log]]></phrase>
+    <phrase title="admin_navigation_addon_rebuild_caches" version_id="1030000" version_string="1.3.0"><![CDATA[Rebuild Caches]]></phrase>
     <phrase title="admin_navigation_InstallUpgrade" version_id="2" version_string="0.2"><![CDATA[Install & Upgrade]]></phrase>
     <phrase title="admin_navigation_UpdateCheck" version_id="6" version_string="1.0.0"><![CDATA[Update Checker {updates}]]></phrase>
     <phrase title="an_unexpected_error_occurred_while_extracting_addons" version_id="1000470" version_string="1.0.4"><![CDATA[An unexpected error occurred while extracting add-ons. Make sure the install/addons directory exists and is writable. If it is, you may have some other permissions related problems that you should consult your host or server person about.]]></phrase>
@@ -465,6 +481,7 @@ $1]]></replace>
     <phrase title="check_updates_automatically" version_id="6" version_string="1.0.0"><![CDATA[Check for updates automatically]]></phrase>
     <phrase title="choose_an_add_on" version_id="1" version_string="0.1"><![CDATA[Choose an add-on]]></phrase>
     <phrase title="configure_addon_update" version_id="6" version_string="1.0.0"><![CDATA[Configure Add-on Update]]></phrase>
+    <phrase title="confirm_rebuild_of_add_on_caches" version_id="1030000" version_string="1.3.0"><![CDATA[Confirm rebuild of add-on caches]]></phrase>
     <phrase title="confirm_skip_current_update" version_id="10" version_string="1.0.0 RC4"><![CDATA[Confirm Ignore Current Update]]></phrase>
     <phrase title="confirm_skip_update" version_id="10" version_string="1.0.0 RC4"><![CDATA[Confirm Ignore Update]]></phrase>
     <phrase title="could_not_create_directory_permissions" version_id="1000470" version_string="1.0.4"><![CDATA[Could not create temporary install directory. Please verify permissions are correct to write to the install/addons directory.]]></phrase>
@@ -496,6 +513,7 @@ $1]]></replace>
     <phrase title="option_xenforoRmLoginPassword_explain" version_id="11" version_string="1.0.0 RC5"><![CDATA[Please remember (much like your SMTP settings) no effort is made to encrypt this sensitive credential. It is stored in the database as plain text.]]></phrase>
     <phrase title="option_xenforoRmLoginUsername" version_id="10" version_string="1.0.0 RC4"><![CDATA[XenForo Username]]></phrase>
     <phrase title="option_xenforoRmLoginUsername_explain" version_id="10" version_string="1.0.0 RC4"><![CDATA[]]></phrase>
+    <phrase title="please_confirm_that_you_want_to_rebuild_add_on_caches" version_id="1030000" version_string="1.3.0"><![CDATA[Please confirm that you want to rebuild add-on caches. This is a computationally expensive task and may impact board performance.]]></phrase>
     <phrase title="please_confirm_you_want_to_skip_update_explain" version_id="10" version_string="1.0.0 RC4"><![CDATA[Please confirm below that you want to ignore this current update.
 <br /><br />
 You may want to do this if the developer did not update the add-on XML file with the latest version and you have already installed this update.

--- a/upload/library/AddOnInstaller/ControllerAdmin/AddOn.php
+++ b/upload/library/AddOnInstaller/ControllerAdmin/AddOn.php
@@ -667,4 +667,21 @@ class AddOnInstaller_ControllerAdmin_AddOn extends XFCP_AddOnInstaller_Controlle
             XenForo_Link::buildAdminLink('add-ons/update-check')
         );
     }
+
+    public function actionRebuildCaches()
+    {
+        if ($this->isConfirmedPost())
+        {
+            $caches = $this->_getAddOnModel()->rebuildAddOnCaches();
+
+            return XenForo_CacheRebuilder_Abstract::getRebuilderResponse(
+                $this, $caches,
+                XenForo_Link::buildAdminLink('add-ons')
+            );
+        }
+        else
+        {           
+            return $this->responseView('AddOnInstaller_ViewAdmin_Install', 'addon_rebuild_caches');
+        }
+    }
 }


### PR DESCRIPTION
Every so often, the I've had the need to restart the add-on caches being rebuilt. Generally as a result of interrupting a previous install, uninstall, or disable/enable add-on.

This adds a new link which allows this to be done much faster than installing another add-on.
