### PR TITLE
Faster installer and XF2 compatibility fixes

### DIFF
--- a/addon-AddOnInstaller.xml
+++ b/addon-AddOnInstaller.xml
@@ -561,7 +561,7 @@ This class MUST be defined as follows:</p>
       <relation group_id="addOnInstaller" display_order="30"/>
     </option>
     <option option_id="addoninstaller_faster_install" edit_format="onoff" data_type="boolean" can_backup="1">
-      <default_value>1</default_value>
+      <default_value>0</default_value>
       <edit_format_params></edit_format_params>
       <sub_options></sub_options>
       <relation group_id="addOnInstaller" display_order="50"/>

--- a/addon-AddOnInstaller.xml
+++ b/addon-AddOnInstaller.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<addon addon_id="AddOnInstaller" title="Add-on Install &amp; Upgrade" version_string="1.3.5" version_id="1030570" url="https://xenforo.com/community/resources/add-on-install-upgrade.960/" install_callback_class="AddOnInstaller_Install" install_callback_method="installer" uninstall_callback_class="AddOnInstaller_Install" uninstall_callback_method="uninstaller">
+<addon addon_id="AddOnInstaller" title="Add-on Install &amp; Upgrade" version_string="1.4.0" version_id="1040070" url="https://xenforo.com/community/resources/add-on-install-upgrade.960/" install_callback_class="AddOnInstaller_Install" install_callback_method="installer" uninstall_callback_class="AddOnInstaller_Install" uninstall_callback_method="uninstaller">
   <admin_navigation>
     <navigation navigation_id="AddonInstallLog" parent_navigation_id="addOns" display_order="300" link="add-ons/install-log" admin_permission_id="addOn" debug_only="0" hide_no_children="0"/>
     <navigation navigation_id="InstallUpgrade" parent_navigation_id="addOns" display_order="100" link="add-ons/install-upgrade" admin_permission_id="addOn" debug_only="0" hide_no_children="0"/>
@@ -529,10 +529,19 @@ This class MUST be defined as follows:</p>
     <listener event_id="load_class" execute_order="10" callback_class="AddOnInstaller_Listener" callback_method="extendAddOnController" active="1" hint="XenForo_ControllerAdmin_AddOn" description="XenForo_ControllerAdmin_AddOn"/>
     <listener event_id="load_class" execute_order="10" callback_class="AddOnInstaller_Listener" callback_method="extendAddOnDataWriter" active="1" hint="XenForo_DataWriter_AddOn" description="XenForo_DataWriter_AddOn"/>
     <listener event_id="load_class" execute_order="10" callback_class="AddOnInstaller_Listener" callback_method="extendAddOnModel" active="1" hint="XenForo_Model_AddOn" description="XenForo_Model_AddOn"/>
+    <listener event_id="load_class" execute_order="10" callback_class="AddOnInstaller_Listener" callback_method="load_class" active="1" hint="XenForo_Deferred_Template" description="XenForo_Deferred_Template"/>
+    <listener event_id="load_class" execute_order="10" callback_class="AddOnInstaller_Listener" callback_method="load_class" active="1" hint="XenForo_Deferred_TemplateReparse" description="XenForo_Deferred_TemplateReparse"/>
+    <listener event_id="load_class_datawriter" execute_order="10" callback_class="AddOnInstaller_Listener" callback_method="load_class" active="1" hint="XenForo_DataWriter_AdminTemplate" description="XenForo_DataWriter_AdminTemplate"/>
+    <listener event_id="load_class_datawriter" execute_order="10" callback_class="AddOnInstaller_Listener" callback_method="load_class" active="1" hint="XenForo_DataWriter_AdminTemplateModification" description="XenForo_DataWriter_AdminTemplateModification"/>
+    <listener event_id="load_class_datawriter" execute_order="10" callback_class="AddOnInstaller_Listener" callback_method="load_class" active="1" hint="XenForo_DataWriter_EmailTemplate" description="XenForo_DataWriter_EmailTemplate"/>
+    <listener event_id="load_class_datawriter" execute_order="10" callback_class="AddOnInstaller_Listener" callback_method="load_class" active="1" hint="XenForo_DataWriter_EmailTemplateModification" description="XenForo_DataWriter_EmailTemplateModification"/>
+    <listener event_id="load_class_datawriter" execute_order="10" callback_class="AddOnInstaller_Listener" callback_method="load_class" active="1" hint="XenForo_DataWriter_Template" description="XenForo_DataWriter_Template"/>
+    <listener event_id="load_class_datawriter" execute_order="10" callback_class="AddOnInstaller_Listener" callback_method="load_class" active="1" hint="XenForo_DataWriter_TemplateModification" description="XenForo_DataWriter_TemplateModification"/>
+    <listener event_id="load_class_model" execute_order="10" callback_class="AddOnInstaller_Listener" callback_method="load_class" active="1" hint="XenForo_Model_Template" description="XenForo_Model_Template"/>
     <listener event_id="template_file_change" execute_order="10" callback_class="AddOnInstaller_Listener" callback_method="template_file_change" active="1" hint="" description="Ensure opcache invalidation happens."/>
   </code_event_listeners>
   <cron>
-    <entry entry_id="AddOnInstallerUpdateCheck" cron_class="AddOnInstaller_CronEntry_UpdateCheck" cron_method="checkUpdates" active="1"><![CDATA[{"day_type":"dom","dom":["-1"],"hours":[18],"minutes":[34]}]]></entry>
+    <entry entry_id="AddOnInstallerUpdateCheck" cron_class="AddOnInstaller_CronEntry_UpdateCheck" cron_method="checkUpdates" active="1"><![CDATA[{"day_type":"dom","dom":["-1"],"hours":[22],"minutes":[6]}]]></entry>
   </cron>
   <email_templates/>
   <email_template_modifications/>
@@ -550,6 +559,12 @@ This class MUST be defined as follows:</p>
       <edit_format_params></edit_format_params>
       <sub_options></sub_options>
       <relation group_id="addOnInstaller" display_order="30"/>
+    </option>
+    <option option_id="addoninstaller_faster_install" edit_format="onoff" data_type="boolean" can_backup="1">
+      <default_value>1</default_value>
+      <edit_format_params></edit_format_params>
+      <sub_options></sub_options>
+      <relation group_id="addOnInstaller" display_order="50"/>
     </option>
     <option option_id="addoninstaller_update_confirmsbatch" edit_format="onoff" data_type="boolean" can_backup="1">
       <default_value>1</default_value>
@@ -668,6 +683,8 @@ timeout</sub_options>
     <phrase title="option_addoninstaller_check_update_explain" version_id="1020000" version_string="1.2.0"><![CDATA[Periodically check for add-on updates.]]></phrase>
     <phrase title="option_addoninstaller_exact_check" version_id="1030470" version_string="1.3.4"><![CDATA[Exact version check]]></phrase>
     <phrase title="option_addoninstaller_exact_check_explain" version_id="1030470" version_string="1.3.4"><![CDATA[If enabled, does an exact string comparison rather than <a href="http://php.net/manual/en/function.version-compare.php">php-standardized version</a> comparison.]]></phrase>
+    <phrase title="option_addoninstaller_faster_install" version_id="1040070" version_string="1.4.0"><![CDATA[Faster Install]]></phrase>
+    <phrase title="option_addoninstaller_faster_install_explain" version_id="1040070" version_string="1.4.0"><![CDATA[By only recompiling changed add-on templates, installing can be dramatically faster.]]></phrase>
     <phrase title="option_addoninstaller_update_confirmsbatch" version_id="1030100" version_string="1.3.1"><![CDATA[Update checker auto-confirms batch]]></phrase>
     <phrase title="option_addoninstaller_update_confirmsbatch_explain" version_id="1030100" version_string="1.3.1"><![CDATA[If set, the install link from updater automatically confirms installing]]></phrase>
     <phrase title="option_builtin_deploymentmethods" version_id="1030004" version_string="1.3.0 Alpha 4"><![CDATA[Built-in add-on deployment methods]]></phrase>

--- a/upload/library/AddOnInstaller/DataWriter/InstallBatch.php
+++ b/upload/library/AddOnInstaller/DataWriter/InstallBatch.php
@@ -18,6 +18,7 @@ class AddOnInstaller_DataWriter_InstallBatch extends XenForo_DataWriter
                 'deploy_method'          => array('type' => self::TYPE_STRING, 'required' => true, 'maxLength' => 50),
                 'user_id'                => array('type' => self::TYPE_UINT, 'required' => true),
                 'username'               => array('type' => self::TYPE_STRING, 'required' => true, 'maxLength' => 50),
+                'changeTracking'         => array('type' => self::TYPE_SERIALIZED, 'default' => ''),
             ),
         );
     }

--- a/upload/library/AddOnInstaller/DataWriter/InstallBatch.php
+++ b/upload/library/AddOnInstaller/DataWriter/InstallBatch.php
@@ -18,7 +18,7 @@ class AddOnInstaller_DataWriter_InstallBatch extends XenForo_DataWriter
                 'deploy_method'          => array('type' => self::TYPE_STRING, 'required' => true, 'maxLength' => 50),
                 'user_id'                => array('type' => self::TYPE_UINT, 'required' => true),
                 'username'               => array('type' => self::TYPE_STRING, 'required' => true, 'maxLength' => 50),
-                'changeTracking'         => array('type' => self::TYPE_SERIALIZED, 'default' => ''),
+                'changeTracking'         => array('type' => self::TYPE_SERIALIZED, 'default' => null),
             ),
         );
     }

--- a/upload/library/AddOnInstaller/DataWriter/InstallBatch.php
+++ b/upload/library/AddOnInstaller/DataWriter/InstallBatch.php
@@ -9,7 +9,7 @@ class AddOnInstaller_DataWriter_InstallBatch extends XenForo_DataWriter
     */
     protected function _getFields()
     {
-        return array(
+        $fields = array(
             'xf_addon_install_batch' => array(
                 'addon_install_batch_id' => array('type' => self::TYPE_UINT, 'autoIncrement' => true),
                 'install_date'           => array('type' => self::TYPE_UINT, 'required' => true, 'default' => XenForo_Application::$time),
@@ -18,9 +18,13 @@ class AddOnInstaller_DataWriter_InstallBatch extends XenForo_DataWriter
                 'deploy_method'          => array('type' => self::TYPE_STRING, 'required' => true, 'maxLength' => 50),
                 'user_id'                => array('type' => self::TYPE_UINT, 'required' => true),
                 'username'               => array('type' => self::TYPE_STRING, 'required' => true, 'maxLength' => 50),
-                'changeTracking'         => array('type' => self::TYPE_SERIALIZED, 'default' => null),
             ),
         );
+        if (AddOnInstaller_Install::doesColumnExist('xf_addon_install_batch', 'changeTracking'))
+        {
+            $fields['xf_addon_install_batch']['changeTracking'] = array('type' => self::TYPE_SERIALIZED, 'default' => null);
+        }
+        return $fields;
     }
 
     /**

--- a/upload/library/AddOnInstaller/Install.php
+++ b/upload/library/AddOnInstaller/Install.php
@@ -36,6 +36,7 @@ class AddOnInstaller_Install
             `deploy_method` VARCHAR(50) NOT NULL DEFAULT 'copy',
             `user_id` int(10) unsigned NOT NULL DEFAULT 0,
             `username` VARCHAR(50) NOT NULL DEFAULT '',
+            `changeTracking` blob DEFAULT null,
             PRIMARY KEY (`addon_install_batch_id`),
             KEY (`install_date`)
         ) ENGINE=InnoDB CHARACTER SET utf8 COLLATE utf8_general_ci");
@@ -66,6 +67,7 @@ class AddOnInstaller_Install
         ) ENGINE=InnoDB CHARACTER SET utf8 COLLATE utf8_general_ci");
 
         self::addRemoveColumn('xf_addon_update_check', 'skip_version', 'add', "varchar(30) NOT NULL DEFAULT ''", 'latest_version');
+        self::addRemoveColumn('xf_addon_install_batch', 'changeTracking', 'add', "blob DEFAULT null", 'username');
 
         if ($xml)
         {
@@ -79,7 +81,7 @@ class AddOnInstaller_Install
             }
         }
 
-        // if this addon is disabled, and then upgraded via XenForo addon upgrade proccess, 
+        // if this addon is disabled, and then upgraded via XenForo addon upgrade proccess,
         // the method that is expected to exist will not.
         $addOnModel = XenForo_Model::create("XenForo_Model_AddOn");
         if (method_exists($addOnModel, 'bulkUpdateAddOnCheck'))

--- a/upload/library/AddOnInstaller/Tools.php
+++ b/upload/library/AddOnInstaller/Tools.php
@@ -35,7 +35,7 @@ class AddOnInstaller_Tools
         }
         // merge with any existing lists
         foreach($_changeTracking as $type => $value)
-        {                
+        {
             if (isset(self::$_typeMap[$type]) && isset(self::$_changeTracking[$type]) && is_array(self::$_changeTracking[$type]))
             {
                 self::$_changeTracking[$type] = array_unique(array_merge(self::$_changeTracking[$type], $value));
@@ -44,7 +44,7 @@ class AddOnInstaller_Tools
             {
                 self::$_changeTracking[$type] = $value;
             }
-                
+
         }
     }
 
@@ -52,7 +52,7 @@ class AddOnInstaller_Tools
         'admin' => array(),
         'public' => array(),
         'email' => array(),
-        'permissionHash' => null, 
+        'permissionHash' => null,
     );
 
     protected static $_typeMap = array(
@@ -65,7 +65,7 @@ class AddOnInstaller_Tools
     {
         self::$_changeTracking['permissionHash'] = $hash;
     }
-    
+
     public static function getPermissionsHash()
     {
         return self::$_changeTracking['permissionHash'];

--- a/upload/library/AddOnInstaller/Tools.php
+++ b/upload/library/AddOnInstaller/Tools.php
@@ -1,0 +1,42 @@
+<?php
+
+class AddOnInstaller_Tools
+{
+    protected static $_changedTemplates = [
+        'admin' => [],
+        'public' => [],
+        'email' => []
+    ];
+
+    protected static $_typeMap = [
+        'admin' => ['AdminTemplateReparse', 'AdminTemplate'],
+        'public' => ['TemplateReparse', 'Template'],
+        'email' => ['EmailTemplateReparse', 'EmailTemplate'],
+    ];
+
+    public static function addTemplateToData($type, $templateTitle)
+    {
+        self::$_changedTemplates[$type][] = $templateTitle;
+    }
+
+    public static function getDataForRebuild()
+    {
+        $output = [];
+
+        foreach (self::$_changedTemplates AS $type => $templates)
+        {
+            $templates = array_unique($templates);
+
+            sort($templates);
+
+            $output[] = [
+                'classes' => self::$_typeMap[$type],
+                'data' => [
+                    'templates' => $templates
+                ]
+            ];
+        }
+
+        return $output;
+    }
+}

--- a/upload/library/AddOnInstaller/Tools.php
+++ b/upload/library/AddOnInstaller/Tools.php
@@ -29,17 +29,17 @@ class AddOnInstaller_Tools
         }
     }
 
-    protected static $_changedTemplates = [
-        'admin' => [],
-        'public' => [],
-        'email' => []
-    ];
+    protected static $_changedTemplates = array(
+        'admin' => array(),
+        'public' => array(),
+        'email' => array(),
+    );
 
-    protected static $_typeMap = [
-        'admin' => ['AdminTemplateReparse', 'AdminTemplate'],
-        'public' => ['TemplateReparse', 'Template'],
-        'email' => ['EmailTemplateReparse', 'EmailTemplate'],
-    ];
+    protected static $_typeMap = array(
+        'admin' => array('AdminTemplateReparse', 'AdminTemplate'),
+        'public' => array('TemplateReparse', 'Template'),
+        'email' => array('EmailTemplateReparse', 'EmailTemplate'),
+    );
 
     public static function addTemplateToData($type, $templateTitle)
     {
@@ -48,7 +48,7 @@ class AddOnInstaller_Tools
 
     public static function getDataForRebuild()
     {
-        $output = [];
+        $output = array();
 
         foreach (self::$_changedTemplates AS $type => $templates)
         {
@@ -56,12 +56,12 @@ class AddOnInstaller_Tools
 
             sort($templates);
 
-            $output[] = [
+            $output[] = array(
                 'classes' => self::$_typeMap[$type],
-                'data' => [
+                'data' => array(
                     'templates' => $templates
-                ]
-            ];
+                ),
+            );
         }
 
         return $output;

--- a/upload/library/AddOnInstaller/Tools.php
+++ b/upload/library/AddOnInstaller/Tools.php
@@ -2,6 +2,33 @@
 
 class AddOnInstaller_Tools
 {
+    public function save()
+    {
+        $_changedTemplates = array();
+        foreach(self::$_changedTemplates as $type => $templates)
+        {
+            $_changedTemplates[$type] = array_unique($templates);
+        }
+        return $_changedTemplates;
+    }
+
+    public function load($_changedTemplates)
+    {
+        if ($_changedTemplates && is_string($_changedTemplates))
+        {
+            $_changedTemplates = @unserialize($_changedTemplates);
+        }
+        if (!is_array($_changedTemplates))
+        {
+            return;
+        }
+        // merge with any existing lists
+        foreach($_changedTemplates as $type => $templates)
+        {
+            self::$_changedTemplates[$type] = array_unique(array_merge(self::$_changedTemplates[$type], $templates));
+        }
+    }
+
     protected static $_changedTemplates = [
         'admin' => [],
         'public' => [],

--- a/upload/library/AddOnInstaller/Tools.php
+++ b/upload/library/AddOnInstaller/Tools.php
@@ -2,7 +2,7 @@
 
 class AddOnInstaller_Tools
 {
-    public function save()
+    public static function save()
     {
         $_changedTemplates = array();
         foreach(self::$_changedTemplates as $type => $templates)
@@ -12,7 +12,7 @@ class AddOnInstaller_Tools
         return $_changedTemplates;
     }
 
-    public function load($_changedTemplates)
+    public static function load($_changedTemplates)
     {
         if ($_changedTemplates && is_string($_changedTemplates))
         {

--- a/upload/library/AddOnInstaller/XenForo/ControllerAdmin/AddOn.php
+++ b/upload/library/AddOnInstaller/XenForo/ControllerAdmin/AddOn.php
@@ -496,7 +496,10 @@ class AddOnInstaller_XenForo_ControllerAdmin_AddOn extends XFCP_AddOnInstaller_X
         $installed_addons = false;
         $options = XenForo_Application::getOptions();
         $options->set('addoninstaller_supress_cache_rebuild', true);
-        AddOnInstaller_Tools::load($batch['changeTracking']);
+        if (isset($batch['changeTracking']))
+        {
+            AddOnInstaller_Tools::load($batch['changeTracking']);
+        }
         // invalidate opcode cache to reduce errors when the listeners change
         $addOnModel->InvalidateOpCache();
         try
@@ -616,10 +619,17 @@ class AddOnInstaller_XenForo_ControllerAdmin_AddOn extends XFCP_AddOnInstaller_X
 
         if ($options->addoninstaller_cache_rebuild_required)
         {
-            $dw = XenForo_DataWriter::create('AddOnInstaller_DataWriter_Updater');
-            $dw->setExistingData($batch);
-            $dw->set('changeTracking', AddOnInstaller_Tools::save());
-            $dw->save();
+            if (isset($batch['changeTracking']))
+            {
+                $dw = XenForo_DataWriter::create('AddOnInstaller_DataWriter_Updater');
+                $dw->setExistingData($batch);
+                $dw->set('changeTracking', AddOnInstaller_Tools::save());
+                $dw->save();
+            }
+            else
+            {
+                $options->set('addoninstaller_faster_install', false);
+            }
             $options->set('addoninstaller_supress_cache_rebuild', false);
         }
         $addOnModel->rebuildAddOnCaches();

--- a/upload/library/AddOnInstaller/XenForo/ControllerAdmin/AddOn.php
+++ b/upload/library/AddOnInstaller/XenForo/ControllerAdmin/AddOn.php
@@ -496,6 +496,7 @@ class AddOnInstaller_XenForo_ControllerAdmin_AddOn extends XFCP_AddOnInstaller_X
         $installed_addons = false;
         $options = XenForo_Application::getOptions();
         $options->set('addoninstaller_supress_cache_rebuild', true);
+        AddOnInstaller_Tools::load($batch['changeTracking']);
         // invalidate opcode cache to reduce errors when the listeners change
         $addOnModel->InvalidateOpCache();
         try
@@ -607,6 +608,7 @@ class AddOnInstaller_XenForo_ControllerAdmin_AddOn extends XFCP_AddOnInstaller_X
             if ($options->addoninstaller_cache_rebuild_required)
             {
                 $options->set('addoninstaller_supress_cache_rebuild', false);
+                $options->set('addoninstaller_faster_install', false);
             }
             $addOnModel->rebuildAddOnCaches();
             throw $e;
@@ -614,6 +616,10 @@ class AddOnInstaller_XenForo_ControllerAdmin_AddOn extends XFCP_AddOnInstaller_X
 
         if ($options->addoninstaller_cache_rebuild_required)
         {
+            $dw = XenForo_DataWriter::create('AddOnInstaller_DataWriter_Updater');
+            $dw->setExistingData($batch);
+            $dw->set('changeTracking', AddOnInstaller_Tools::save());
+            $dw->save();
             $options->set('addoninstaller_supress_cache_rebuild', false);
         }
         $addOnModel->rebuildAddOnCaches();

--- a/upload/library/AddOnInstaller/XenForo/ControllerAdmin/AddOn.php
+++ b/upload/library/AddOnInstaller/XenForo/ControllerAdmin/AddOn.php
@@ -804,6 +804,7 @@ class AddOnInstaller_XenForo_ControllerAdmin_AddOn extends XFCP_AddOnInstaller_X
     {
         if ($this->isConfirmedPost())
         {
+            XenForo_Application::getOptions()->set('addoninstaller_faster_install', false);
             $caches = $this->_getAddOnModel()->rebuildAddOnCaches();
 
             return XenForo_CacheRebuilder_Abstract::getRebuilderResponse(

--- a/upload/library/AddOnInstaller/XenForo/ControllerAdmin/AddOn.php
+++ b/upload/library/AddOnInstaller/XenForo/ControllerAdmin/AddOn.php
@@ -617,19 +617,20 @@ class AddOnInstaller_XenForo_ControllerAdmin_AddOn extends XFCP_AddOnInstaller_X
             throw $e;
         }
 
+        // changeTracking can be null, don't use isset()
+        if (array_key_exists('changeTracking', $batch))
+        {
+            $dw = XenForo_DataWriter::create('AddOnInstaller_DataWriter_InstallBatch');
+            $dw->setExistingData($batch);
+            $dw->set('changeTracking', AddOnInstaller_Tools::save());
+            $dw->save();
+        }
+        else
+        {
+            $options->set('addoninstaller_faster_install', false);
+        }
         if ($options->addoninstaller_cache_rebuild_required)
         {
-            if (isset($batch['changeTracking']))
-            {
-                $dw = XenForo_DataWriter::create('AddOnInstaller_DataWriter_InstallBatch');
-                $dw->setExistingData($batch);
-                $dw->set('changeTracking', AddOnInstaller_Tools::save());
-                $dw->save();
-            }
-            else
-            {
-                $options->set('addoninstaller_faster_install', false);
-            }
             $options->set('addoninstaller_supress_cache_rebuild', false);
         }
         $addOnModel->rebuildAddOnCaches();

--- a/upload/library/AddOnInstaller/XenForo/ControllerAdmin/AddOn.php
+++ b/upload/library/AddOnInstaller/XenForo/ControllerAdmin/AddOn.php
@@ -621,7 +621,7 @@ class AddOnInstaller_XenForo_ControllerAdmin_AddOn extends XFCP_AddOnInstaller_X
         {
             if (isset($batch['changeTracking']))
             {
-                $dw = XenForo_DataWriter::create('AddOnInstaller_DataWriter_Updater');
+                $dw = XenForo_DataWriter::create('AddOnInstaller_DataWriter_InstallBatch');
                 $dw->setExistingData($batch);
                 $dw->set('changeTracking', AddOnInstaller_Tools::save());
                 $dw->save();

--- a/upload/library/AddOnInstaller/XenForo/DataWriter/AdminTemplate.php
+++ b/upload/library/AddOnInstaller/XenForo/DataWriter/AdminTemplate.php
@@ -1,0 +1,21 @@
+<?php
+
+class AddOnInstaller_XenForo_DataWriter_AdminTemplate extends XFCP_AddOnInstaller_XenForo_DataWriter_AdminTemplate
+{
+    protected function _postSaveAfterTransaction()
+    {
+        parent::_postSaveAfterTransaction();
+
+        if ($this->get('addon_id') && XenForo_Application::isRegistered('nf_addoninstallimprove_installing'))
+        {
+            AddOnInstaller_Tools::addTemplateToData('admin', $this->get('title'));
+        }
+    }
+}
+
+if (false)
+{
+    class XFCP_AddOnInstaller_XenForo_DataWriter_AdminTemplate extends XenForo_DataWriter_AdminTemplate
+    {
+    }
+}

--- a/upload/library/AddOnInstaller/XenForo/DataWriter/AdminTemplateModification.php
+++ b/upload/library/AddOnInstaller/XenForo/DataWriter/AdminTemplateModification.php
@@ -1,0 +1,21 @@
+<?php
+
+class AddOnInstaller_XenForo_DataWriter_AdminTemplateModification extends XFCP_AddOnInstaller_XenForo_DataWriter_AdminTemplateModification
+{
+    protected function _postSaveAfterTransaction()
+    {
+        parent::_postSaveAfterTransaction();
+
+        if ($this->get('addon_id') && XenForo_Application::isRegistered('nf_addoninstallimprove_installing'))
+        {
+            AddOnInstaller_Tools::addTemplateToData('admin', $this->get('template'));
+        }
+    }
+}
+
+if (false)
+{
+    class XFCP_AddOnInstaller_XenForo_DataWriter_AdminTemplateModification extends XenForo_DataWriter_AdminTemplateModification
+    {
+    }
+}

--- a/upload/library/AddOnInstaller/XenForo/DataWriter/EmailTemplate.php
+++ b/upload/library/AddOnInstaller/XenForo/DataWriter/EmailTemplate.php
@@ -1,0 +1,21 @@
+<?php
+
+class AddOnInstaller_XenForo_DataWriter_EmailTemplate extends XFCP_AddOnInstaller_XenForo_DataWriter_EmailTemplate
+{
+    protected function _postSaveAfterTransaction()
+    {
+        parent::_postSaveAfterTransaction();
+
+        if ($this->get('addon_id') && XenForo_Application::isRegistered('nf_addoninstallimprove_installing'))
+        {
+            AddOnInstaller_Tools::addTemplateToData('email', $this->get('title'));
+        }
+    }
+}
+
+if (false)
+{
+    class XFCP_AddOnInstaller_XenForo_DataWriter_EmailTemplate extends XenForo_DataWriter_EmailTemplate
+    {
+    }
+}

--- a/upload/library/AddOnInstaller/XenForo/DataWriter/EmailTemplateModification.php
+++ b/upload/library/AddOnInstaller/XenForo/DataWriter/EmailTemplateModification.php
@@ -1,0 +1,21 @@
+<?php
+
+class AddOnInstaller_XenForo_DataWriter_EmailTemplateModification extends XFCP_AddOnInstaller_XenForo_DataWriter_EmailTemplateModification
+{
+    protected function _postSaveAfterTransaction()
+    {
+        parent::_postSaveAfterTransaction();
+
+        if ($this->get('addon_id') && XenForo_Application::isRegistered('nf_addoninstallimprove_installing'))
+        {
+            AddOnInstaller_Tools::addTemplateToData('email', $this->get('template'));
+        }
+    }
+}
+
+if (false)
+{
+    class XFCP_AddOnInstaller_XenForo_DataWriter_EmailTemplateModification extends XenForo_DataWriter_EmailTemplateModification
+    {
+    }
+}

--- a/upload/library/AddOnInstaller/XenForo/DataWriter/Template.php
+++ b/upload/library/AddOnInstaller/XenForo/DataWriter/Template.php
@@ -1,0 +1,21 @@
+<?php
+
+class AddOnInstaller_XenForo_DataWriter_Template extends XFCP_AddOnInstaller_XenForo_DataWriter_Template
+{
+    protected function _postSaveAfterTransaction()
+    {
+        parent::_postSaveAfterTransaction();
+
+        if ($this->get('addon_id') && XenForo_Application::isRegistered('nf_addoninstallimprove_installing'))
+        {
+            AddOnInstaller_Tools::addTemplateToData('public', $this->get('title'));
+        }
+    }
+}
+
+if (false)
+{
+    class XFCP_AddOnInstaller_XenForo_DataWriter_Template extends XenForo_DataWriter_Template
+    {
+    }
+}

--- a/upload/library/AddOnInstaller/XenForo/DataWriter/TemplateModification.php
+++ b/upload/library/AddOnInstaller/XenForo/DataWriter/TemplateModification.php
@@ -1,0 +1,21 @@
+<?php
+
+class AddOnInstaller_XenForo_DataWriter_TemplateModification extends XFCP_AddOnInstaller_XenForo_DataWriter_TemplateModification
+{
+    protected function _postSaveAfterTransaction()
+    {
+        parent::_postSaveAfterTransaction();
+
+        if ($this->get('addon_id') && XenForo_Application::isRegistered('nf_addoninstallimprove_installing'))
+        {
+            AddOnInstaller_Tools::addTemplateToData('public', $this->get('template'));
+        }
+    }
+}
+
+if (false)
+{
+    class XFCP_AddOnInstaller_XenForo_DataWriter_TemplateModification extends XenForo_DataWriter_TemplateModification
+    {
+    }
+}

--- a/upload/library/AddOnInstaller/XenForo/Deferred/Template.php
+++ b/upload/library/AddOnInstaller/XenForo/Deferred/Template.php
@@ -1,0 +1,71 @@
+<?php
+
+class AddOnInstaller_XenForo_Deferred_Template extends XFCP_AddOnInstaller_XenForo_Deferred_Template
+{
+    public function execute(array $deferred, array $data, $targetRunTime, &$status)
+    {
+        if (!isset($data['templates']))
+        {
+            return parent::execute($deferred, $data, $targetRunTime, $status);
+        }
+
+        $data = array_merge([
+            'startStyle' => 0,
+            'position' => 0,
+            'mapped' => false,
+            'templates' => []
+        ], $data);
+
+        /* @var $templateModel AddOnInstaller_XenForo_Model_Template */
+        $templateModel = XenForo_Model::create('XenForo_Model_Template');
+
+        if ($data['startStyle'] == 0 && !$data['mapped'])
+        {
+            $s = microtime(true);
+            $templateModel->insertTemplateMapForStyles($templateModel->buildTemplateMapForStyleTree(0), true);
+            $data['mapped'] = true;
+
+            $maxExec = ($targetRunTime ? $targetRunTime - (microtime(true) - $s) : 0);
+        }
+        else
+        {
+            $maxExec = $targetRunTime;
+        }
+
+        $actionPhrase = new XenForo_Phrase('rebuilding');
+        $typePhrase = new XenForo_Phrase('templates');
+        $status = sprintf('%s... %s %s', $actionPhrase, $typePhrase, str_repeat(' . ', $data['position']));
+
+        if (!$targetRunTime || $maxExec > 1)
+        {
+            $result = $templateModel->compileNamedTemplates($data['templates'], $maxExec, $data['startStyle']);
+        }
+        else
+        {
+            $result = false;
+        }
+
+        if ($result === true)
+        {
+            return true;
+        }
+        else
+        {
+            if ($result)
+            {
+                $data['startStyle'] = $result[0];
+                $data['templates'] = $result[1];
+            }
+            $data['position']++;
+
+            return $data;
+        }
+    }
+}
+
+if (false)
+{
+    class XFCP_AddOnInstaller_XenForo_Deferred_Template extends XenForo_Deferred_Template
+    {
+    }
+}

--- a/upload/library/AddOnInstaller/XenForo/Deferred/Template.php
+++ b/upload/library/AddOnInstaller/XenForo/Deferred/Template.php
@@ -9,12 +9,13 @@ class AddOnInstaller_XenForo_Deferred_Template extends XFCP_AddOnInstaller_XenFo
             return parent::execute($deferred, $data, $targetRunTime, $status);
         }
 
-        $data = array_merge([
+        $data = array_merge(array(
             'startStyle' => 0,
+            'startTemplate' => null,
             'position' => 0,
             'mapped' => false,
-            'templates' => []
-        ], $data);
+            'templates' => array(),
+        ), $data);
 
         /* @var $templateModel AddOnInstaller_XenForo_Model_Template */
         $templateModel = XenForo_Model::create('XenForo_Model_Template');
@@ -54,7 +55,8 @@ class AddOnInstaller_XenForo_Deferred_Template extends XFCP_AddOnInstaller_XenFo
             if ($result)
             {
                 $data['startStyle'] = $result[0];
-                $data['templates'] = $result[1];
+                $data['startTemplate'] = $result[1];
+                $data['templates'] = $result[2];
             }
             $data['position']++;
 

--- a/upload/library/AddOnInstaller/XenForo/Deferred/TemplateReparse.php
+++ b/upload/library/AddOnInstaller/XenForo/Deferred/TemplateReparse.php
@@ -1,0 +1,51 @@
+<?php
+
+class AddOnInstaller_XenForo_Deferred_TemplateReparse extends XFCP_AddOnInstaller_XenForo_Deferred_TemplateReparse
+{
+    public function execute(array $deferred, array $data, $targetRunTime, &$status)
+    {
+        if (!isset($data['templates']))
+        {
+            return parent::execute($deferred, $data, $targetRunTime, $status);
+        }
+
+        $data = array_merge([
+            'startStyle' => 0,
+            'startTemplate' => 0,
+            'position' => 0,
+            'templates' => [],
+        ], $data);
+
+        /* @var $templateModel AddOnInstaller_XenForo_Model_Template */
+        $templateModel = XenForo_Model::create('XenForo_Model_Template');
+
+        $actionPhrase = new XenForo_Phrase('reparsing');
+        $typePhrase = new XenForo_Phrase('templates');
+        $status = sprintf('%s... %s %s', $actionPhrase, $typePhrase, str_repeat(' . ', $data['position']));
+
+        $result = $templateModel->reparseNamedTemplates($data['templates'], $targetRunTime, $data['startStyle']);
+
+        if ($result === true)
+        {
+            return true;
+        }
+        else
+        {
+            if ($result)
+            {
+                $data['startStyle'] = $result[0];
+                $data['templates'] = $result[1];
+            }
+            $data['position']++;
+
+            return $data;
+        }
+    }
+}
+
+if (false)
+{
+    class XFCP_AddOnInstaller_XenForo_Deferred_TemplateReparse extends XenForo_Deferred_TemplateReparse
+    {
+    }
+}

--- a/upload/library/AddOnInstaller/XenForo/Deferred/TemplateReparse.php
+++ b/upload/library/AddOnInstaller/XenForo/Deferred/TemplateReparse.php
@@ -9,12 +9,13 @@ class AddOnInstaller_XenForo_Deferred_TemplateReparse extends XFCP_AddOnInstalle
             return parent::execute($deferred, $data, $targetRunTime, $status);
         }
 
-        $data = array_merge([
+        $data = array_merge(array(
             'startStyle' => 0,
+            'startTemplate' => null,
             'startTemplate' => 0,
             'position' => 0,
-            'templates' => [],
-        ], $data);
+            'templates' => array(),
+        ), $data);
 
         /* @var $templateModel AddOnInstaller_XenForo_Model_Template */
         $templateModel = XenForo_Model::create('XenForo_Model_Template');
@@ -22,6 +23,11 @@ class AddOnInstaller_XenForo_Deferred_TemplateReparse extends XFCP_AddOnInstalle
         $actionPhrase = new XenForo_Phrase('reparsing');
         $typePhrase = new XenForo_Phrase('templates');
         $status = sprintf('%s... %s %s', $actionPhrase, $typePhrase, str_repeat(' . ', $data['position']));
+
+        if (empty($data['templates']))
+        {
+            return false;
+        }
 
         $result = $templateModel->reparseNamedTemplates($data['templates'], $targetRunTime, $data['startStyle']);
 
@@ -34,7 +40,8 @@ class AddOnInstaller_XenForo_Deferred_TemplateReparse extends XFCP_AddOnInstalle
             if ($result)
             {
                 $data['startStyle'] = $result[0];
-                $data['templates'] = $result[1];
+                $data['startTemplate'] = $result[1];
+                $data['templates'] = $result[2];
             }
             $data['position']++;
 

--- a/upload/library/AddOnInstaller/XenForo/Model/AddOn.php
+++ b/upload/library/AddOnInstaller/XenForo/Model/AddOn.php
@@ -913,6 +913,7 @@ class AddOnInstaller_XenForo_Model_AddOn extends XFCP_AddOnInstaller_XenForo_Mod
             }
 
             XenForo_Application::defer('Atomic', $atomicData, 'addonRebuild', true);
+            return;
         }
 
         parent::rebuildAddOnCaches();

--- a/upload/library/AddOnInstaller/XenForo/Model/AddOn.php
+++ b/upload/library/AddOnInstaller/XenForo/Model/AddOn.php
@@ -843,6 +843,7 @@ class AddOnInstaller_XenForo_Model_AddOn extends XFCP_AddOnInstaller_XenForo_Mod
         $installBatch = XenForo_DataWriter::create("AddOnInstaller_DataWriter_InstallBatch");
         $installBatch->setExistingData($batch);
         $installBatch->set('is_completed', $all_installed);
+        //$installBatch->set('changeTracking', null);
         $installBatch->save();
 
         return true;
@@ -894,12 +895,12 @@ class AddOnInstaller_XenForo_Model_AddOn extends XFCP_AddOnInstaller_XenForo_Mod
 
             $this->getModelFromCache('XenForo_Model_Option')->updateOption('jsLastUpdate', XenForo_Application::$time);
 
-            $atomicData = [
-                'execute' => [
-                    ['Permission', []],
-                    ['Phrase', []],
-                ]
-            ];
+            $atomicData = array(
+                'execute' => array(
+                    array('Permission', array()),
+                    array('Phrase', array()),
+                ),
+            );
 
             $changedTemplates = AddOnInstaller_Tools::getDataForRebuild();
 

--- a/upload/library/AddOnInstaller/XenForo/Model/AddOn.php
+++ b/upload/library/AddOnInstaller/XenForo/Model/AddOn.php
@@ -726,6 +726,13 @@ class AddOnInstaller_XenForo_Model_AddOn extends XFCP_AddOnInstaller_XenForo_Mod
         return $dw;
     }
 
+    public function getPermissionsHash()
+    {
+        $permissionModel = $this->getModelFromCache('XenForo_Model_Permission');
+        $hash = array($permissionModel->getAllPermissionEntriesGrouped(), $permissionModel->getAllPermissionsGrouped());
+        return sha1(serialize($hash));
+    }
+
     protected function createBatchDirectory($path)
     {
         try
@@ -896,11 +903,14 @@ class AddOnInstaller_XenForo_Model_AddOn extends XFCP_AddOnInstaller_XenForo_Mod
             $this->getModelFromCache('XenForo_Model_Option')->updateOption('jsLastUpdate', XenForo_Application::$time);
 
             $atomicData = array(
-                'execute' => array(
-                    array('Permission', array()),
-                    array('Phrase', array()),
-                ),
+                'execute' => array(),
             );
+
+            if ($this->getPermissionsHash() != AddOnInstaller_Tools::getPermissionsHash())
+            {
+                $atomicData['execute'][] = array('Permission', array());
+            }
+            $atomicData['execute'][] = array('Phrase', array());
 
             $changedTemplates = AddOnInstaller_Tools::getDataForRebuild();
 

--- a/upload/library/AddOnInstaller/XenForo/Model/AddOn.php
+++ b/upload/library/AddOnInstaller/XenForo/Model/AddOn.php
@@ -381,7 +381,7 @@ class AddOnInstaller_XenForo_Model_AddOn extends XFCP_AddOnInstaller_XenForo_Mod
 
     public function isDownloadUrl($downloadUrl)
     {
-        $pattern = '#(resources/[a-z0-9_\-]+\.[0-9]+/download\?version=[0-9]+)#';
+        $pattern = '#(resources\/[a-z0-9_\-]+\.[0-9]+\/(version\/[0-9]+\/)?download)#';
 
         preg_match($pattern, $downloadUrl, $matches);
 
@@ -591,19 +591,19 @@ class AddOnInstaller_XenForo_Model_AddOn extends XFCP_AddOnInstaller_XenForo_Mod
 
         $client->setCookieJar();
 
-        $client->setParameterPost(array('login' => $username, 'password' => $password, 'redirect' => $resourceUrl));
+        $client->setParameterPost(array('login' => $username, 'password' => $password, '_xfRedirect' => $resourceUrl));
 
         $login = $client->request('POST');
 
         $dom = new Zend_Dom_Query($login->getBody());
-        $loggedIn = $dom->query('html .LoggedIn');
+        $loggedIn = $dom->query('html[data-logged-in="true"]');
 
         if (!$loggedIn->count())
         {
             throw new XenForo_Exception(new XenForo_Phrase('login_to_xenforo_has_failed'), true);
         }
 
-        $downloadButton = $dom->query('.downloadButton a');
+        $downloadButton = $dom->query('a.button--icon--download');
 
         if (!$downloadButton->count())
         {
@@ -617,7 +617,7 @@ class AddOnInstaller_XenForo_Model_AddOn extends XFCP_AddOnInstaller_XenForo_Mod
             throw new XenForo_Exception(new XenForo_Phrase('no_download_url_found_maybe_paid'), true);
         }
 
-        $client->setUri('https://xenforo.com/community/' . $downloadUrl);
+        $client->setUri('https://xenforo.com' . $downloadUrl);
 
         $response = $client->request('GET');
         $content_disposition = $response->getHeader("Content-Disposition");

--- a/upload/library/AddOnInstaller/XenForo/Model/Template.php
+++ b/upload/library/AddOnInstaller/XenForo/Model/Template.php
@@ -92,6 +92,7 @@ class AddOnInstaller_XenForo_Model_Template extends XFCP_AddOnInstaller_XenForo_
             }
         }
 
+        $compiledRemove = array();
         if ($complete)
         {
             $compiledRemove = $db->fetchAll("
@@ -105,10 +106,6 @@ class AddOnInstaller_XenForo_Model_Template extends XFCP_AddOnInstaller_XenForo_
                 $db->delete('xf_template_compiled',
                     "style_id = " . $db->quote($remove['style_id']) . " AND title = " . $db->quote($remove['title'])
                 );
-                if (XenForo_Application::get('options')->templateFiles)
-                {
-                    XenForo_Template_FileHandler::delete($remove['title'], $remove['style_id'], null);
-                }
             }
 
             $this->getModelFromCache('XenForo_Model_Style')->updateAllStylesLastModifiedDate();
@@ -116,6 +113,13 @@ class AddOnInstaller_XenForo_Model_Template extends XFCP_AddOnInstaller_XenForo_
         }
 
         XenForo_Db::commit($db);
+        if (XenForo_Application::get('options')->templateFiles)
+        {
+            foreach($compiledRemove as $remove)
+            {
+                XenForo_Template_FileHandler::delete($remove['title'], $remove['style_id'], null);
+            }
+        }
 
         if ($complete)
         {

--- a/upload/library/AddOnInstaller/XenForo/Model/Template.php
+++ b/upload/library/AddOnInstaller/XenForo/Model/Template.php
@@ -31,7 +31,7 @@ class AddOnInstaller_XenForo_Model_Template extends XFCP_AddOnInstaller_XenForo_
             ksort($fullTemplates);
             foreach ($fullTemplates AS $key => $template)
             {
-                if ($lastTemplate && stcmp($key, $lastTemplate) < 0)
+                if ($lastTemplate && strcmp($key, $lastTemplate) < 0)
                 {
                     continue;
                 }
@@ -88,7 +88,7 @@ class AddOnInstaller_XenForo_Model_Template extends XFCP_AddOnInstaller_XenForo_
             ksort($fullTemplates);
             foreach ($fullTemplates AS $key => $template)
             {
-                if ($lastTemplate && stcmp($key, $lastTemplate) < 0)
+                if ($lastTemplate && strcmp($key, $lastTemplate) < 0)
                 {
                     continue;
                 }

--- a/upload/library/AddOnInstaller/XenForo/Model/Template.php
+++ b/upload/library/AddOnInstaller/XenForo/Model/Template.php
@@ -11,6 +11,7 @@ class AddOnInstaller_XenForo_Model_Template extends XFCP_AddOnInstaller_XenForo_
         sort($styleIds);
 
         $lastStyle = 0;
+        $lastTemplate = null;
         $startTime = microtime(true);
         $complete = true;
 
@@ -26,10 +27,15 @@ class AddOnInstaller_XenForo_Model_Template extends XFCP_AddOnInstaller_XenForo_
             $lastStyle = $styleId;
             $lastTemplate = null;
 
-            $templates = $this->getTemplatesInStyleByTitles($templates, $styleId);
-            foreach ($templates AS $key => $template)
+            $fullTemplates = $this->getTemplatesInStyleByTitles($templates, $styleId);
+            ksort($fullTemplates);
+            foreach ($fullTemplates AS $key => $template)
             {
-                unset($templates[$key]);
+                if ($lastTemplate && stcmp($key, $lastTemplate) < 0)
+                {
+                    continue;
+                }
+                $lastTemplate = $key;
 
                 $this->reparseTemplate($template, false);
 
@@ -49,7 +55,7 @@ class AddOnInstaller_XenForo_Model_Template extends XFCP_AddOnInstaller_XenForo_
         }
         else
         {
-            return [$lastStyle, $templates];
+            return array($lastStyle, $lastTemplate, $templates);
         }
     }
 
@@ -62,6 +68,7 @@ class AddOnInstaller_XenForo_Model_Template extends XFCP_AddOnInstaller_XenForo_
         sort($styleIds);
 
         $lastStyle = 0;
+        $lastTemplate = null;
         $startTime = microtime(true);
         $complete = true;
 
@@ -75,12 +82,17 @@ class AddOnInstaller_XenForo_Model_Template extends XFCP_AddOnInstaller_XenForo_
             }
 
             $lastStyle = $styleId;
-            $lastTemplate = 0;
+            $lastTemplate = null;
 
-            $templates = $this->getTemplatesInStyleByTitles($templates, $styleId);
-            foreach ($templates AS $key => $template)
+            $fullTemplates = $this->getTemplatesInStyleByTitles($templates, $styleId);
+            ksort($fullTemplates);
+            foreach ($fullTemplates AS $key => $template)
             {
-                unset($templates[$key]);
+                if ($lastTemplate && stcmp($key, $lastTemplate) < 0)
+                {
+                    continue;
+                }
+                $lastTemplate = $key;
 
                 $this->compileNamedTemplateInStyleTree($template['title'], $template['style_id']);
 
@@ -127,7 +139,7 @@ class AddOnInstaller_XenForo_Model_Template extends XFCP_AddOnInstaller_XenForo_
         }
         else
         {
-            return array($lastStyle, $templates);
+            return array($lastStyle, $lastTemplate, $templates);
         }
     }
 }

--- a/upload/library/AddOnInstaller/XenForo/Model/Template.php
+++ b/upload/library/AddOnInstaller/XenForo/Model/Template.php
@@ -1,0 +1,136 @@
+<?php
+
+class AddOnInstaller_XenForo_Model_Template extends XFCP_AddOnInstaller_XenForo_Model_Template
+{
+    public function reparseNamedTemplates(array $templates, $maxExecution = 0, $startStyle = 0)
+    {
+        $db = $this->_getDb();
+
+        $styles = $this->getModelFromCache('XenForo_Model_Style')->getAllStyles();
+        $styleIds = array_merge([0], array_keys($styles));
+        sort($styleIds);
+
+        $lastStyle = 0;
+        $startTime = microtime(true);
+        $complete = true;
+
+        XenForo_Db::beginTransaction($db);
+
+        foreach ($styleIds AS $styleId)
+        {
+            if ($styleId < $startStyle)
+            {
+                continue;
+            }
+
+            $lastStyle = $styleId;
+            $lastTemplate = null;
+
+            $templates = $this->getTemplatesInStyleByTitles($templates, $styleId);
+            foreach ($templates AS $key => $template)
+            {
+                unset($templates[$key]);
+
+                $this->reparseTemplate($template, false);
+
+                if ($maxExecution && (microtime(true) - $startTime) > $maxExecution)
+                {
+                    $complete = false;
+                    break 2;
+                }
+            }
+        }
+
+        XenForo_Db::commit($db);
+
+        if ($complete)
+        {
+            return true;
+        }
+        else
+        {
+            return [$lastStyle, $templates];
+        }
+    }
+
+    public function compileNamedTemplates(array $templates, $maxExecution = 0, $startStyle = 0)
+    {
+        $db = $this->_getDb();
+
+        $styles = $this->getModelFromCache('XenForo_Model_Style')->getAllStyles();
+        $styleIds = array_merge(array(0), array_keys($styles));
+        sort($styleIds);
+
+        $lastStyle = 0;
+        $startTime = microtime(true);
+        $complete = true;
+
+        XenForo_Db::beginTransaction($db);
+
+        foreach ($styleIds AS $styleId)
+        {
+            if ($styleId < $startStyle)
+            {
+                continue;
+            }
+
+            $lastStyle = $styleId;
+            $lastTemplate = 0;
+
+            $templates = $this->getTemplatesInStyleByTitles($templates, $styleId);
+            foreach ($templates AS $key => $template)
+            {
+                unset($templates[$key]);
+
+                $this->compileNamedTemplateInStyleTree($template['title'], $template['style_id']);
+
+                if ($maxExecution && (microtime(true) - $startTime) > $maxExecution)
+                {
+                    $complete = false;
+                    break 2;
+                }
+            }
+        }
+
+        if ($complete)
+        {
+            $compiledRemove = $db->fetchAll("
+				SELECT DISTINCT c.title, c.style_id
+				FROM xf_template_compiled AS c
+				LEFT JOIN xf_template_map AS m ON (c.title = m.title AND c.style_id = m.style_id)
+				WHERE m.title IS NULL
+			");
+            foreach ($compiledRemove AS $remove)
+            {
+                $db->delete('xf_template_compiled',
+                    "style_id = " . $db->quote($remove['style_id']) . " AND title = " . $db->quote($remove['title'])
+                );
+                if (XenForo_Application::get('options')->templateFiles)
+                {
+                    XenForo_Template_FileHandler::delete($remove['title'], $remove['style_id'], null);
+                }
+            }
+
+            $this->getModelFromCache('XenForo_Model_Style')->updateAllStylesLastModifiedDate();
+            $this->getModelFromCache('XenForo_Model_AdminTemplate')->updateAdminStyleLastModifiedDate();
+        }
+
+        XenForo_Db::commit($db);
+
+        if ($complete)
+        {
+            return true;
+        }
+        else
+        {
+            return array($lastStyle, $templates);
+        }
+    }
+}
+
+if (false)
+{
+    class XFCP_AddOnInstaller_XenForo_Model_Template extends XenForo_Model_Template
+    {
+    }
+}

--- a/upload/library/AddOnInstaller/addon-AddOnInstaller.xml
+++ b/upload/library/AddOnInstaller/addon-AddOnInstaller.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<addon addon_id="AddOnInstaller" title="Add-on Install &amp; Upgrade" version_string="1.3.5" version_id="1030570" url="https://xenforo.com/community/resources/add-on-install-upgrade.960/" install_callback_class="AddOnInstaller_Install" install_callback_method="installer" uninstall_callback_class="AddOnInstaller_Install" uninstall_callback_method="uninstaller">
+<addon addon_id="AddOnInstaller" title="Add-on Install &amp; Upgrade" version_string="1.4.0" version_id="1040070" url="https://xenforo.com/community/resources/add-on-install-upgrade.960/" install_callback_class="AddOnInstaller_Install" install_callback_method="installer" uninstall_callback_class="AddOnInstaller_Install" uninstall_callback_method="uninstaller">
   <admin_navigation>
     <navigation navigation_id="AddonInstallLog" parent_navigation_id="addOns" display_order="300" link="add-ons/install-log" admin_permission_id="addOn" debug_only="0" hide_no_children="0"/>
     <navigation navigation_id="InstallUpgrade" parent_navigation_id="addOns" display_order="100" link="add-ons/install-upgrade" admin_permission_id="addOn" debug_only="0" hide_no_children="0"/>
@@ -529,10 +529,19 @@ This class MUST be defined as follows:</p>
     <listener event_id="load_class" execute_order="10" callback_class="AddOnInstaller_Listener" callback_method="extendAddOnController" active="1" hint="XenForo_ControllerAdmin_AddOn" description="XenForo_ControllerAdmin_AddOn"/>
     <listener event_id="load_class" execute_order="10" callback_class="AddOnInstaller_Listener" callback_method="extendAddOnDataWriter" active="1" hint="XenForo_DataWriter_AddOn" description="XenForo_DataWriter_AddOn"/>
     <listener event_id="load_class" execute_order="10" callback_class="AddOnInstaller_Listener" callback_method="extendAddOnModel" active="1" hint="XenForo_Model_AddOn" description="XenForo_Model_AddOn"/>
+    <listener event_id="load_class" execute_order="10" callback_class="AddOnInstaller_Listener" callback_method="load_class" active="1" hint="XenForo_Deferred_Template" description="XenForo_Deferred_Template"/>
+    <listener event_id="load_class" execute_order="10" callback_class="AddOnInstaller_Listener" callback_method="load_class" active="1" hint="XenForo_Deferred_TemplateReparse" description="XenForo_Deferred_TemplateReparse"/>
+    <listener event_id="load_class_datawriter" execute_order="10" callback_class="AddOnInstaller_Listener" callback_method="load_class" active="1" hint="XenForo_DataWriter_AdminTemplate" description="XenForo_DataWriter_AdminTemplate"/>
+    <listener event_id="load_class_datawriter" execute_order="10" callback_class="AddOnInstaller_Listener" callback_method="load_class" active="1" hint="XenForo_DataWriter_AdminTemplateModification" description="XenForo_DataWriter_AdminTemplateModification"/>
+    <listener event_id="load_class_datawriter" execute_order="10" callback_class="AddOnInstaller_Listener" callback_method="load_class" active="1" hint="XenForo_DataWriter_EmailTemplate" description="XenForo_DataWriter_EmailTemplate"/>
+    <listener event_id="load_class_datawriter" execute_order="10" callback_class="AddOnInstaller_Listener" callback_method="load_class" active="1" hint="XenForo_DataWriter_EmailTemplateModification" description="XenForo_DataWriter_EmailTemplateModification"/>
+    <listener event_id="load_class_datawriter" execute_order="10" callback_class="AddOnInstaller_Listener" callback_method="load_class" active="1" hint="XenForo_DataWriter_Template" description="XenForo_DataWriter_Template"/>
+    <listener event_id="load_class_datawriter" execute_order="10" callback_class="AddOnInstaller_Listener" callback_method="load_class" active="1" hint="XenForo_DataWriter_TemplateModification" description="XenForo_DataWriter_TemplateModification"/>
+    <listener event_id="load_class_model" execute_order="10" callback_class="AddOnInstaller_Listener" callback_method="load_class" active="1" hint="XenForo_Model_Template" description="XenForo_Model_Template"/>
     <listener event_id="template_file_change" execute_order="10" callback_class="AddOnInstaller_Listener" callback_method="template_file_change" active="1" hint="" description="Ensure opcache invalidation happens."/>
   </code_event_listeners>
   <cron>
-    <entry entry_id="AddOnInstallerUpdateCheck" cron_class="AddOnInstaller_CronEntry_UpdateCheck" cron_method="checkUpdates" active="1"><![CDATA[{"day_type":"dom","dom":["-1"],"hours":[18],"minutes":[34]}]]></entry>
+    <entry entry_id="AddOnInstallerUpdateCheck" cron_class="AddOnInstaller_CronEntry_UpdateCheck" cron_method="checkUpdates" active="1"><![CDATA[{"day_type":"dom","dom":["-1"],"hours":[22],"minutes":[6]}]]></entry>
   </cron>
   <email_templates/>
   <email_template_modifications/>
@@ -550,6 +559,12 @@ This class MUST be defined as follows:</p>
       <edit_format_params></edit_format_params>
       <sub_options></sub_options>
       <relation group_id="addOnInstaller" display_order="30"/>
+    </option>
+    <option option_id="addoninstaller_faster_install" edit_format="onoff" data_type="boolean" can_backup="1">
+      <default_value>1</default_value>
+      <edit_format_params></edit_format_params>
+      <sub_options></sub_options>
+      <relation group_id="addOnInstaller" display_order="50"/>
     </option>
     <option option_id="addoninstaller_update_confirmsbatch" edit_format="onoff" data_type="boolean" can_backup="1">
       <default_value>1</default_value>
@@ -668,6 +683,8 @@ timeout</sub_options>
     <phrase title="option_addoninstaller_check_update_explain" version_id="1020000" version_string="1.2.0"><![CDATA[Periodically check for add-on updates.]]></phrase>
     <phrase title="option_addoninstaller_exact_check" version_id="1030470" version_string="1.3.4"><![CDATA[Exact version check]]></phrase>
     <phrase title="option_addoninstaller_exact_check_explain" version_id="1030470" version_string="1.3.4"><![CDATA[If enabled, does an exact string comparison rather than <a href="http://php.net/manual/en/function.version-compare.php">php-standardized version</a> comparison.]]></phrase>
+    <phrase title="option_addoninstaller_faster_install" version_id="1040070" version_string="1.4.0"><![CDATA[Faster Install]]></phrase>
+    <phrase title="option_addoninstaller_faster_install_explain" version_id="1040070" version_string="1.4.0"><![CDATA[By only recompiling changed add-on templates, installing can be dramatically faster.]]></phrase>
     <phrase title="option_addoninstaller_update_confirmsbatch" version_id="1030100" version_string="1.3.1"><![CDATA[Update checker auto-confirms batch]]></phrase>
     <phrase title="option_addoninstaller_update_confirmsbatch_explain" version_id="1030100" version_string="1.3.1"><![CDATA[If set, the install link from updater automatically confirms installing]]></phrase>
     <phrase title="option_builtin_deploymentmethods" version_id="1030004" version_string="1.3.0 Alpha 4"><![CDATA[Built-in add-on deployment methods]]></phrase>


### PR DESCRIPTION
- Compatibility fixes to support xenforo.com/community running xenforo 2
- Speed up add-on install time by only rebuilding touched templates and permissions

This release has been tested by Xon and myself for a few weeks on an assortment of large boards with smooth operation and less time to go make a coffee or two been add-on upgrades.